### PR TITLE
fix octagonemmc image build

### DIFF
--- a/conf/machine/include/octagon-hisi.inc
+++ b/conf/machine/include/octagon-hisi.inc
@@ -106,6 +106,7 @@ IMAGE_CMD_octagonemmc_append = "\
     mkdir -p ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs3; \
     mkdir -p ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs4; \
     cp -a ${IMAGE_ROOTFS}/* ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs1/; \
+    dd if=/dev/zero of=${DEPLOY_DIR_IMAGE}/${MACHINE}-partitions/rootfs.ext4 seek=${IMAGE_ROOTFS_SIZE} count=60 bs=1024; \
     mkfs.ext4 -F -i 4096 ${DEPLOY_DIR_IMAGE}/${MACHINE}-partitions/rootfs.ext4 -d ${DEPLOY_DIR_IMAGE}/userdata; \
     cd ${IMAGE_ROOTFS}; \
     tar -cvf ${DEPLOY_DIR_IMAGE}/rootfs.tar -C ${IMAGE_ROOTFS} .; \


### PR DESCRIPTION
This commit fixes the following issue shown after clean build on zeus branch.

ERROR: openpli-enigma2-image-1.0-r0 do_image_octagonemmc: Execution of '/zeus/build/tmp/work/sf8008-oe-linux-gnueabi/openpli-enigma2-image/1.0-r0/temp/run.do_image_octagonemmc.16493' failed with exit code 1:
mke2fs 1.45.3 (14-Jul-2019)
The file /zeus/build/tmp/deploy/images/sf8008/sf8008-partitions/rootfs.ext4 does not exist and no size was specified.
WARNING: exit code 1 from a shell command.