### PR TITLE
octagon-opengl-hisi3798mv200: restrict it to COMPATIBLE_MACHINE

### DIFF
--- a/recipes-graphics/octagon-opengl-hisi3798mv200.bb
+++ b/recipes-graphics/octagon-opengl-hisi3798mv200.bb
@@ -4,3 +4,5 @@ SRC_URI[md5sum] = "faf96419cc542a5fe0df49fd2914a7ad"
 SRC_URI[sha256sum] = "7614f03c1db3641ea8793c28fcfdaa74cf45a31f89a7df14114b522fb5576d6e"
 
 require octagon-opengl.inc
+
+COMPATIBLE_MACHINE = "^(sf8008|sf8008m)$"


### PR DESCRIPTION
The driver otherwise slips in other builds as virtual/egl provider:

 octagon-opengl-hisi3798mv200 PROVIDES virtual/egl but was skipped:
 PREFERRED_PROVIDER_virtual/libgles1 set to zgemma-v3ddriver-i55,
 not octagon-opengl-hisi3798mv200

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>